### PR TITLE
Remove JSX language extension & remove structlint as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "tsc": "tsc --noEmit",
     "test": "jest",
-    "lint": "yarn format && cd ./src && structlint",
+    "lint": "yarn format && cd ./src && node ../bin/structlint",
     "format": "prettier --check \"**/*.{ts,tsx,js,json,md,gql}\"",
     "format:fix": "prettier --write \"**/*.{ts,tsx,js,json,md,gql}\""
   },
@@ -58,7 +58,6 @@
     "babel-jest": "^24.9.0",
     "jest": "^24.9.0",
     "prettier": "^1.19.1",
-    "structlint": "^0.3.1",
     "typescript": "^3.7.4"
   },
   "engines": {

--- a/src/parsers/parser-babel.ts
+++ b/src/parsers/parser-babel.ts
@@ -106,7 +106,6 @@ const parse = (filePath: string): void => {
 
 const extensions = getLanguageExtensions([
   "JavaScript",
-  "JSX",
   "TSX",
   "TypeScript",
 ]);

--- a/src/parsers/parser-babel.ts
+++ b/src/parsers/parser-babel.ts
@@ -104,11 +104,7 @@ const parse = (filePath: string): void => {
   }
 };
 
-const extensions = getLanguageExtensions([
-  "JavaScript",
-  "TSX",
-  "TypeScript",
-]);
+const extensions = getLanguageExtensions(["JavaScript", "TSX", "TypeScript"]);
 
 const canParse = (filePath: string): boolean => {
   const ext = extname(filePath);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2885,9 +2885,9 @@ lines-and-columns@^1.1.6:
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
 linguist-languages@^7.7.0:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/linguist-languages/-/linguist-languages-7.7.0.tgz#c069731f8b307ce301980a4bac4b81bf06a2c351"
-  integrity sha512-6vR1OgfD/YK1xgqVBT3aUx9zurSVeHUsXpVyTilT1o7LW6MNAcGmWy5wwmQAAhvEXxG2PZmktHbQiGtJ5hpGkg==
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/linguist-languages/-/linguist-languages-7.15.0.tgz#a93bed6b93015d8133622cb05da6296890862bfa"
+  integrity sha512-qkSSNDjDDycZ2Wcw+GziNBB3nNo3ddYUInM/PL8Amgwbd9RQ/BKGj2/1d6mdxKgBFnUqZuaDbkIwkE4KUwwmtQ==
 
 load-json-file@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3951,23 +3951,6 @@ strip-eof@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
-structlint@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/structlint/-/structlint-0.3.1.tgz#8e0eb9ac3e79539f3ca1e7eff9800ea0164b6c82"
-  integrity sha512-j8P0m/xvd3FMgoE3FFXB1GaE3wX2w+84kN1YKdZ/MtSKKDQojmCIIlEr8cSjNxMAufywIaKbuCycBhOY2oGPjQ==
-  dependencies:
-    "@babel/parser" "^7.7.7"
-    "@babel/traverse" "^7.7.4"
-    chalk "^3.0.0"
-    cosmiconfig "^6.0.0"
-    debug "^4.1.1"
-    dedent "^0.7.0"
-    globby "^10.0.1"
-    linguist-languages "^7.7.0"
-    lodash "^4.17.15"
-    micromatch "^4.0.2"
-    yup "^0.28.0"
-
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[] Bug fix
[ ] New feature
[x] Other, please explain:

In an update of `linguist-languages` [they removed JSX and added it to Javascript]( https://github.com/ikatyang/linguist-languages/commit/54b511cd81e7122c9698806c94c0b0fa7df53e79#diff-7a16c692c63fa35d0e67b143748ccc82fb03240f230d09b5de302b2e2bbbbbfa)

and this would cause a crash
```
Error: Cannot find module 'linguist-languages/data/JSX'
Require stack:
- /Users/arjun/Documents/GitHub/frontend/node_modules/structlint/src/parsers/utils.ts
- /Users/arjun/Documents/GitHub/frontend/node_modules/structlint/src/parsers/parser-babel.ts
- /Users/arjun/Documents/GitHub/frontend/node_modules/structlint/src/parsers/index.ts
- /Users/arjun/Documents/GitHub/frontend/node_modules/structlint/src/tasks/importsTask.ts
- /Users/arjun/Documents/GitHub/frontend/node_modules/structlint/src/cli/index.ts
- /Users/arjun/Documents/GitHub/frontend/node_modules/structlint/bin/structlint.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:889:15)
    at Function.Module._load (internal/modules/cjs/loader.js:745:27)
    at Module.require (internal/modules/cjs/loader.js:961:19)
    at require (internal/modules/cjs/helpers.js:92:18)
    at /Users/arjun/Documents/GitHub/frontend/node_modules/structlint/src/parsers/utils.ts:3:18
    at Array.map (<anonymous>)
    at Object.getLanguageExtensions (/Users/arjun/Documents/GitHub/frontend/node_modules/structlint/src/parsers/utils.ts:3:6)
    at Object.<anonymous> (/Users/arjun/Documents/GitHub/frontend/node_modules/structlint/src/parsers/parser-babel.ts:107:20)
    at Module._compile (internal/modules/cjs/loader.js:1072:14)
    at Module.m._compile (/Users/arjun/Documents/GitHub/frontend/node_modules/structlint/node_modules/ts-node/src/index.ts:858:23)
```

**What changes did you make? (Give an overview)**
- update linguist-languages dependency version to latest
- remove JSX language extension
- remove structlint as a dependency because it was broken and can't get CI to pass

